### PR TITLE
Do not expose expected hash in verification exception

### DIFF
--- a/src/nuget/Auth0-WCF-Service-JWT/content/net40/JWT.cs
+++ b/src/nuget/Auth0-WCF-Service-JWT/content/net40/JWT.cs
@@ -102,7 +102,7 @@ namespace JWT
 
                 if (decodedCrypto != decodedSignature)
                 {
-                    throw new SignatureVerificationException(string.Format("Invalid signature. Expected {0} got {1}", decodedCrypto, decodedSignature));
+                    throw new SignatureVerificationException("Invalid signature.");
                 }
             }
 

--- a/src/nuget/Auth0-WCF-Service-JWT/content/net45/JWT.cs
+++ b/src/nuget/Auth0-WCF-Service-JWT/content/net45/JWT.cs
@@ -102,7 +102,7 @@ namespace JWT
 
                 if (decodedCrypto != decodedSignature)
                 {
-                    throw new SignatureVerificationException(string.Format("Invalid signature. Expected {0} got {1}", decodedCrypto, decodedSignature));
+                    throw new SignatureVerificationException("Invalid signature.");
                 }
             }
 


### PR DESCRIPTION
**Security**: Do not expose the expected hash in the failure message.